### PR TITLE
Add missing dependency `dateutil`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,6 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    install_requires=['pytz', 'bs4', 'requests'],
+    install_requires=['pytz', 'bs4', 'requests', 'python-dateutil'],
     python_requires='>=3.8',
 )


### PR DESCRIPTION
This adds python-dateutil to the list of required dependencies, which the code imports.  Without this, importing easy_rss will fail if you haven't installed the dateutil package independently. 